### PR TITLE
Generalize f function interface

### DIFF
--- a/src/lib/forbid_adt_integrand.f90
+++ b/src/lib/forbid_adt_integrand.f90
@@ -24,14 +24,16 @@ endtype integrand
 
 abstract interface
   !< Abstract type bound procedures necessary for implementing a concrete extension of the class(integrand).
-  function function_value(self, x) result(f)
+  function function_value(self, x, y, z) result(f)
   !---------------------------------------------------------------------------------------------------------------------------------
   !< f(x), integrand function evaluation.
   !---------------------------------------------------------------------------------------------------------------------------------
   import :: integrand, R_P
-  class(integrand), intent(IN)  :: self !< Integrand field.
-  real(R_P),        intent(IN)  :: x    !< Independent abscissa value.
-  real(R_P)                     :: f    !< Result of the time derivative function of integrand field.
+  class(integrand),    intent(IN) :: self !< Integrand field.
+  real(R_P),           intent(IN) :: x    !< Independent X abscissa value.
+  real(R_P), optional, intent(IN) :: y    !< Independent Y abscissa value.
+  real(R_P), optional, intent(IN) :: z    !< Independent Z abscissa value.
+  real(R_P)                       :: f    !< Result of the time derivative function of integrand field.
   !---------------------------------------------------------------------------------------------------------------------------------
   endfunction function_value
 endinterface

--- a/src/tests/sin/type_sin.f90
+++ b/src/tests/sin/type_sin.f90
@@ -44,12 +44,14 @@ contains
   endsubroutine init
 
   ! ADT integrand deferred methods
-  function sin_x(self, x) result(f)
+  function sin_x(self, x, y, z) result(f)
   !---------------------------------------------------------------------------------------------------------------------------------
   !---------------------------------------------------------------------------------------------------------------------------------
-  class(sinf), intent(IN) :: self !< sin function.
-  real(R_P),   intent(IN) :: x    !< Time.
-  real(R_P)               :: f    !< Result of the time derivative function of integrand field.
+  class(sinf),         intent(IN) :: self !< sin function.
+  real(R_P),           intent(IN) :: x    !< X abscissa.
+  real(R_P), optional, intent(IN) :: y    !< Y abscissa.
+  real(R_P), optional, intent(IN) :: z    !< Z abscissa.
+  real(R_P)                       :: f    !< Result of the time derivative function of integrand field.
   !---------------------------------------------------------------------------------------------------------------------------------
 
   !---------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Generalize f function interface.

Why:

Prepare to the extension to multidimensional function integration.

This change addresses the need by:

Add optional arguments to f abstract interface.

Side effects:

Update sin test.